### PR TITLE
Replace 'group:stone' for digging

### DIFF
--- a/mods/libs/whynot_awards/init.lua
+++ b/mods/libs/whynot_awards/init.lua
@@ -274,7 +274,7 @@ awards.register_award("whynot_stone",{
 	requires = {"whynot_tools"},
 	trigger = {
 		type = "dig",
-		node = "group:stone",
+		node = "default:stone",
 		target = 1,
 	},
 })


### PR DESCRIPTION
Replace 'group:stone' for digging with 'default:stone' to avoid getting other awards like copper and tin which are also part of the group stone.

Fixes #199 